### PR TITLE
Add allComments function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.idea
+.php_cs
+.php_cs.cache
+.phpunit.result.cache
+build
+composer.lock
+coverage
+docs
+phpunit.xml
+phpstan.neon
+testbench.yaml
+vendor
+node_modules
+.php-cs-fixer.cache

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ $comment->hasChildren();
 $post->commentCount();
 ```
 
+### Show comments on a post
+```php
+$post->allComments(); // shows all comments (including children)
+$post->comments(); // shows only top level comments
+```
+
 ---
 
 ## Activation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ This Package makes it easy to implement Commenting system for Eloquent's Models.
 
 ```bash
 php artisan vendor:publish --provider="AliBayat\LaravelCommentable\CommentableServiceProvider"
+```
 
+```bash
 php artisan migrate
 ```
 

--- a/src/Commentable.php
+++ b/src/Commentable.php
@@ -27,6 +27,14 @@ trait Commentable
      */
     public function comments(): MorphMany
     {
+        return $this->morphMany($this->commentableModel(), 'commentable')->whereNull('parent_id');
+    }
+
+    /**
+     * @return mixed
+     */
+    public function allComments(): MorphMany
+    {
         return $this->morphMany($this->commentableModel(), 'commentable');
     }
 
@@ -35,6 +43,15 @@ trait Commentable
      * @return mixed
      */
     public function activeComments(): MorphMany
+    {
+        return $this->morphMany($this->commentableModel(), 'commentable')->whereNull('parent_id')->where('active', true);
+    }
+
+
+    /**
+     * @return mixed
+     */
+    public function allActiveComments(): MorphMany
     {
         return $this->morphMany($this->commentableModel(), 'commentable')->where('active', true);
     }
@@ -97,6 +114,6 @@ trait Commentable
      */
     public function commentCount(): int
     {
-        return $this->comments->count();
+        return $this->allComments()->count();
     }
 }


### PR DESCRIPTION
Using current function will show all comments nested or not:
![image](https://user-images.githubusercontent.com/9788214/161432122-8bace7f9-8a8b-4f4e-8521-cc29352c2d5c.png)

But with refactoring it to show only the ones without `parent_id` will be shown like this:
![image](https://user-images.githubusercontent.com/9788214/161432183-7e88a9c0-e0ea-4760-bbf7-5567d3bf258f.png)
